### PR TITLE
upgrade Node version to 22.x

### DIFF
--- a/infra/module/main.tf
+++ b/infra/module/main.tf
@@ -42,7 +42,7 @@ resource "aws_s3_object" "lambda_zip" {
 
 resource "aws_lambda_function" "lambda" {
   function_name = var.lambda_name
-  runtime       = "nodejs18.x"
+  runtime       = "nodejs22.x"
   handler       = "check_rpc.handler"
   role          = var.lambda_role_arn
 


### PR DESCRIPTION
AWS Lambda Node.js 18 runtime support ends September 1, 2025, requiring upgrade to Node.js 22 to maintain security patches and technical support.